### PR TITLE
Add custom UA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 | Contents                         |
 | :------------------------------- |
-| [Installation](##installation)   |
-| [Configuration](##configuration) |
-| [How To Guide](##usage-guide)    |
-| [Tests](##tests)                 |
+| [Installation](#installation)    |
+| [Configuration](#configuration)  |
+| [How To Guide](#how-to-guide)    |
+| [Contributing](#contributing)    |
 
 ## Installation
 

--- a/cased/__init__.py
+++ b/cased/__init__.py
@@ -50,6 +50,9 @@ redact_before_publishing = False
 # Whether or not to raise an exception, or just log, on errors during publish
 raise_on_publish_errors = True
 
+# Allow extra user-agent data
+extra_ua_data = None
+
 # =============================================================
 # Additional publishers
 # =============================================================

--- a/cased/http/httpclient.py
+++ b/cased/http/httpclient.py
@@ -8,9 +8,14 @@ class HTTPClient:
     @classmethod
     def make_request(cls, method, url, api_key, data=None):
 
+        user_agent = "cased-python/{}".format(cased.VERSION)
+
+        if cased.extra_ua_data:
+            user_agent = user_agent + " ({})".format(cased.extra_ua_data)
+
         headers = {
             "Authorization": "Bearer " + api_key,
-            "User-Agent": "cased-python/{}".format(cased.VERSION),
+            "User-Agent": user_agent,
         }
 
         if method == "get":

--- a/cased/tests/test_config.py
+++ b/cased/tests/test_config.py
@@ -63,6 +63,15 @@ class TestConfig(object):
             "secondary": "policy_test_2",
         }
 
+    def test_extra_ua_data_defaults_to_none(self):
+        reload_config()
+        assert cased.extra_ua_data is None
+
+    def test_extra_ua_data_can_be_set(self):
+        reload_config()
+        cased.extra_ua_data = "library wrap"
+        assert cased.extra_ua_data == "library wrap"
+
     def test_clear_after_publish_default_to_false(self):
         assert not cased.clear_context_after_publishing
 


### PR DESCRIPTION
Allow wrappers/users of `cased-python` to add additional user-agent information.